### PR TITLE
Fix data fetching cache

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -47,7 +47,9 @@ class DataFetcher:
 
         if not self.g:
             print("No GitHub client available, using sample data")
-            return self._get_sample_data()
+            self.cache = self._get_sample_data()
+            self.last_fetch_time = datetime.now()
+            return self.cache
 
         try:
             print(f"Fetching data from GitHub repository: {self.repo_name}")
@@ -257,7 +259,6 @@ class DataFetcher:
                 print(''.join(traceback.format_tb(e.__traceback__)))
             return []
 
-        return filtered_data
 
     def get_metadata(self):
         """Get unique values for filtering"""


### PR DESCRIPTION
## Summary
- ensure DataFetcher caches sample data when GitHub token absent
- remove unreachable statement in `search_use_cases`

## Testing
- `python -m py_compile app.py data_fetcher.py api/index.py api/test.py`
- `PORT=5002 python app.py` *(fails to run due to interactive environment)*

------
https://chatgpt.com/codex/tasks/task_e_68509be54f888321a21d606cc829ba71