### PR TITLE
Add dashboard heading test

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,42 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+// Mock axios to avoid parsing its ESM build during tests
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+  get: jest.fn()
+}));
+
+test('renders Use Case Name heading', async () => {
+  const axios = require('axios');
+
+  // Mock the metadata and use case responses
+  axios.default.get
+    .mockResolvedValueOnce({
+      data: { agencies: [], topics: [], statuses: [] }
+    })
+    .mockResolvedValueOnce({
+      data: {
+        items: [
+          {
+            id: 1,
+            name: 'Test Case',
+            agency: 'Agency',
+            agency_abbrev: 'A',
+            topic: 'Topic',
+            purpose: 'Purpose',
+            outputs: 'Outputs',
+            status: 'Testing'
+          }
+        ],
+        total_items: 1,
+        total_pages: 1
+      }
+    });
+
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+
+  const headingElement = await screen.findByText(/Use Case Name/i);
+  expect(headingElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- test `<App />` renders real dashboard heading

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850ab6644b083218cdf44f4b99cc81f